### PR TITLE
feat: partial attribute completion

### DIFF
--- a/src/service/completion.ts
+++ b/src/service/completion.ts
@@ -48,17 +48,22 @@ export function getCompletions(doc: DocumentLike, sourceFile: SourceFile, positi
 		}
 	}
 
+	const prevNodeNi = findNodeAtOffset(g, node.pos - 1, false);
+
+	if (node.kind === SyntaxKind.AttributeContainer
+		// FIXME: conflitcs with #issue 17 9 (last test of nodeCompletion.spec.ts)
+		// || (node.kind == SyntaxKind.TextIdentifier && prevNodeNi?.kind === SyntaxKind.AttributeContainer)
+		|| (node.kind == SyntaxKind.TextIdentifier && prevNodeNi?.kind === SyntaxKind.CommaToken)
+		|| (node.kind == SyntaxKind.CommaToken && parent?.kind === SyntaxKind.Assignment)
+	) {
+		return getAttributeCompletions(position);
+	}
+
 	if (node.kind === SyntaxKind.TextIdentifier && parent?.kind === SyntaxKind.NodeId) {
 		const exclusions = node.symbol
 			? [node.symbol.name]
 			: undefined;
 		return getNodeCompletions(symbols, exclusions);
-	}
-
-	if (node.kind === SyntaxKind.AttributeContainer
-		|| (node.kind == SyntaxKind.CommaToken && parent?.kind === SyntaxKind.Assignment)
-	) {
-		return getAttributeCompletions(position);
 	}
 
 	const prevNode = findNodeAtOffset(g, node.pos - 1, true);

--- a/tests/completion/attributeCompletion.spec.ts
+++ b/tests/completion/attributeCompletion.spec.ts
@@ -55,6 +55,47 @@ describe("Attribute completion", () => {
 		expect(completions).toHaveLength(attributes.length);
 	});
 
+	// FIXME: currently failing
+	test("should provide completion for attributes (partial input)", () => {
+		const content = `graph {
+			node_name_a -- node_name_b [no];
+		}`;
+		const requestOffset = invokeIndex(content)("[no");
+
+		const [doc, sf] = ensureDocAndSourceFile(content);
+
+		const completions = getCompletions(doc, sf, doc.positionAt(requestOffset));
+
+		expect(completions).toBeDefined();
+		assertExists(completions);
+
+		expect(completions.length).toBeGreaterThan(0);
+		expect(completions.map(getLabel)).not.toContain("node_name_a");
+		expect(completions.map(getLabel)).not.toContain("node_name_b");
+		expect(completions.map(getLabel)).toEqual(attributes);
+		expect(completions).toHaveLength(attributes.length);
+	});
+
+	test("should provide completion for attributes (partial input, preceding item)", () => {
+		const content = `graph {
+			node_name_a -- node_name_b [color=blue, no];
+		}`;
+		const requestOffset = invokeIndex(content)(", no");
+
+		const [doc, sf] = ensureDocAndSourceFile(content);
+
+		const completions = getCompletions(doc, sf, doc.positionAt(requestOffset));
+
+		expect(completions).toBeDefined();
+		assertExists(completions);
+
+		expect(completions.length).toBeGreaterThan(0);
+		expect(completions.map(getLabel)).not.toContain("node_name_a");
+		expect(completions.map(getLabel)).not.toContain("node_name_b");
+		expect(completions.map(getLabel)).toEqual(attributes);
+		expect(completions).toHaveLength(attributes.length);
+	});
+
 	test("should provide completion for attributes (preceding item)", () => {
 		const content = `graph {
 			node_name_a -- node_name_b [color=blue,];


### PR DESCRIPTION
Currently attribute completion only works when being at the beginning of an attribute list or after a comma and need to be triggered manually after inserting `[` or after `,` . Being able to autocomplete attribute when starting to type the attribute name itself is more convinnient. 
Currently the following case doesn't get autocomplete:
```dot
digraph {
  start -> end [sha|]
                // ^ cursor here
}
```
This is an attempt to solve it but I'm stuck on the above case, the current node is `TextIdentifier` and the previous node kind type is `AttributeContainer` but this is also the case in the following situation (#17):
```dot
digraph {
  start -> end [color=blue]
  s|
// ^ cursor here
}
```
